### PR TITLE
get basic grpc_gateway_proto_library and grpc_gateway_swagger_compile to work

### DIFF
--- a/tests/grpc_gateway/proto/BUILD
+++ b/tests/grpc_gateway/proto/BUILD
@@ -1,3 +1,4 @@
+
 load("@org_pubref_rules_protobuf//go:rules.bzl", "go_proto_library")
 load("@org_pubref_rules_protobuf//grpc_gateway:rules.bzl", "grpc_gateway_proto_library", "grpc_gateway_swagger_compile")
 
@@ -15,7 +16,7 @@ go_proto_library(
     deps = [
         "@com_github_golang_protobuf//ptypes/any:go_default_library",
     ],
-    verbose = 0,
+    verbose = 2,
 )
 
 grpc_gateway_proto_library(
@@ -23,18 +24,20 @@ grpc_gateway_proto_library(
     protos = [
         "greeter.proto",
     ],
-    importpath = "github.com/pubref/rules_protobuf/greeter",
-    deps = [
-        ":messages"
+    proto_deps = [
+        ":messages",
     ],
+    importpath = "github.com/pubref/rules_protobuf/greeter",
     visibility = [
         "//visibility:public",
     ],
+    verbose = 2,
 )
 
 grpc_gateway_swagger_compile(
     name = "greeter_swagger",
     protos = [
         "greeter.proto",
+        "message.proto",
     ],
 )

--- a/tests/grpc_gateway/proto/greeter.proto
+++ b/tests/grpc_gateway/proto/greeter.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 import "google/api/annotations.proto";
 import "proto/message.proto";
 
+package helloworld;
 
 // The greeting service definition.  Note that the
 // protoc-gen-grpc-gateway plugin will skip and service/rpc

--- a/tests/grpc_gateway/proto/message.proto
+++ b/tests/grpc_gateway/proto/message.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package helloworld;
+
 message HelloRequest {
   string name = 1;
 }


### PR DESCRIPTION
- Changed deps to proto_deps so the files would be included correctly.
- Declared a package name to work around "--swagger_out: inconsistent package names: greeter message"